### PR TITLE
fix: wrong API path in browser example

### DIFF
--- a/examples/browser/index.html
+++ b/examples/browser/index.html
@@ -14,37 +14,39 @@
             <th>High/Low</th>
             <th>Level (meters)</th>
           </tr>
-          <tbody id="tides">
-
-          </tbody>
+          <tbody id="tides"></tbody>
         </thead>
       </table>
     </div>
 
-    <script src="../../dist/tide-predictor.js"></script>
+    <script src="../../dist/web/tide-predictor.js"></script>
     <script>
-      (()=> {
-        fetch(
-          'https://tidesandcurrents.noaa.gov/mdapi/v1.0/webapi/stations/9413450/harcon.json?units=metric'
-        )
-        .then(response => {
-          return response.json()
-        }).then(harmonics => {
-          const start = new Date()
-          const end = new Date(start.getTime() + (10 * 24 * 60 * 60 * 1000))
-
-          const highLow = tidePredictor(harmonics.HarmonicConstituents).getExtremesPrediction(start, end)
-          
-          highLow.forEach(level => {
-            const tableRow = document.createElement('tr')
-            tableRow.innerHTML = `
-              <td>${level.time}</td>
-              <td>${level.label}</td>
-              <td>${level.level}</td>
-            `
-            document.getElementById('tides').appendChild(tableRow)
+      (() => {
+        fetch('https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations/9413450/harcon.json?units=metric')
+          .then(response => {
+            return response.json()
           })
-        })
+          .then(harmonics => {
+            const start = new Date()
+            const end = new Date(start.getTime() + (10 * 24 * 60 * 60 * 1000))
+
+            const highLow = tidePredictor(harmonics.HarmonicConstituents).getExtremesPrediction({start, end})
+
+            highLow.forEach(level => {
+              const tableRow = document.createElement('tr')
+              tableRow.innerHTML = `
+              <td>${level
+                .time}</td>
+              <td>${level
+                .label}</td>
+              <td>${level
+                .level}</td>
+            `
+                document
+                .getElementById('tides')
+                .appendChild(tableRow)
+            })
+          })
       })()
     </script>
   </body>


### PR DESCRIPTION
Closes #150 

- Fixes API endpoint that browser example uses to get data from NOAA.
- Fix the include path to the tide predictor library