### PR TITLE
Rename repository to just `neaps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-![example workflow](https://github.com/neaps/tide-predictor/actions/workflows/test.yml/badge.svg) [![codecov](https://codecov.io/gh/neaps/tide-predictor/branch/main/graph/badge.svg?token=KEJK5NQR5H)](https://codecov.io/gh/neaps/tide-predictor)
+![example workflow](https://github.com/neaps/neaps/actions/workflows/test.yml/badge.svg) [![codecov](https://codecov.io/gh/neaps/neaps/branch/main/graph/badge.svg?token=KEJK5NQR5H)](https://codecov.io/gh/neaps/neaps)
 
 # Neaps
 
 A tide prediction engine written in TypeScript.
 
-> [!CAUTION]
+> [!WARNING]
 > **Not for navigational use**
 >
 > Do not use calculations from this project for navigation, or depend on them in any situation where inaccuracies could result in harm to a person or property. Tide predictions are only as good as the harmonics data available, and these can be inconsistent and vary widely based on the accuracy of the source data and local conditions. The tide predictions do not factor events such as storm surge, wind waves, uplift, tsunamis, or sadly, climate change. 😢

--- a/packages/neaps/package.json
+++ b/packages/neaps/package.json
@@ -6,13 +6,14 @@
     "tides",
     "harmonics"
   ],
-  "homepage": "https://github.com/neaps/tide-predictor#readme",
+  "homepage": "https://github.com/neaps/neaps#readme",
   "bugs": {
-    "url": "https://github.com/neaps/tide-predictor/issues"
+    "url": "https://github.com/neaps/neaps/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/neaps/tide-predictor.git"
+    "url": "git+https://github.com/neaps/neaps.git",
+    "directory": "packages/neaps"
   },
   "license": "MIT",
   "author": "Brandon Keepers <brandon@openwaters.io>",

--- a/packages/tide-predictor/README.md
+++ b/packages/tide-predictor/README.md
@@ -1,37 +1,23 @@
-![example workflow](https://github.com/neaps/tide-predictor/actions/workflows/test.yml/badge.svg) [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fneaps%2Ftide-predictor.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fneaps%2Ftide-predictor?ref=badge_shield) [![codecov](https://codecov.io/gh/neaps/tide-predictor/branch/main/graph/badge.svg?token=KEJK5NQR5H)](https://codecov.io/gh/neaps/tide-predictor)
-
-# Tide predictor
+# @neaps/tide-predictor
 
 A tide harmonic calculator written in TypeScript.
 
 <!-- START DOCS -->
 
-## 🚨Warning🚨
-
-**Do not use calculations from this project for navigation, or depend on them in any situation where inaccuracies could result in harm to a person or property.**
-
-Tide predictions are only as good as the harmonics data available, and these can be inconsistent and vary widely based on the accuracy of the source data and local conditions.
-
-The tide predictions do not factor events such as storm surge, wind waves, uplift, tsunamis, or sadly, climate change. 😢
+> [!WARNING]
+> **Not for navigational use**
+>
+> Do not use calculations from this project for navigation, or depend on them in any situation where inaccuracies could result in harm to a person or property. Tide predictions are only as good as the harmonics data available, and these can be inconsistent and vary widely based on the accuracy of the source data and local conditions. The tide predictions do not factor events such as storm surge, wind waves, uplift, tsunamis, or sadly, climate change. 😢
 
 # Installation
 
-```
-#npm
+```sh
 npm install @neaps/tide-predictor
-
-# yarn
-yarn add @neaps/tide-predictor
-
 ```
 
 # Usage
 
-Neaps requires that you [provide your own tidal harmonics information](#constituent-object) to generate a prediction.
-
-Because many constituent datum come with multiple phases (in the case of NOAA's data, they are `phase_local` and `phase_GMT`), there is a `phaseKey` option for choosing which to use.
-
-Note that, for now, Neaps **will not** do any timezone corrections. This means you need to pass date objects that align with whatever timezone the constituents are in.
+`@neaps/tide-predictor` requires that you [provide your own tidal harmonics information](#constituent-object) to generate a prediction. For a complete tide prediction solution, including finding nearby stations and their harmonics, check out the [`neaps` package](https://github.com/neaps/neaps).
 
 ```typescript
 import TidePredictor from '@neaps/tide-predictor'
@@ -55,13 +41,15 @@ const highLowTides = TidePredictor(constituents, {
 })
 ```
 
+Note that, for now, Neaps **will not** do any timezone corrections. This means you need to pass date objects that align with whatever timezone the constituents are in.
+
 ## Tide prediction object
 
 Calling `tidePredictor` will generate a new tide prediction object. It accepts the following arguments:
 
 - `constituents` - An array of [constituent objects](#constituent-object)
 - `options` - An object with one of:
-  - `phaseKey` - The name of the parameter within constituents that is considered the "phase"
+  - `phaseKey` - The name of the parameter within constituents that is considered the "phase" because many constituent datum come with multiple phases (in the case of NOAA's data, they are `phase_local` and `phase_GMT`).
   - `offset` - A value to add to **all** values predicted. This is useful if you want to, for example, offset tides by mean high water, etc.
 
 ### Tide prediction methods

--- a/packages/tide-predictor/package.json
+++ b/packages/tide-predictor/package.json
@@ -2,7 +2,11 @@
   "name": "@neaps/tide-predictor",
   "version": "0.1.1",
   "description": "Tide predictor",
-  "repository": "https://github.com/neaps/tide-predictor",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neaps/neaps",
+    "directory": "packages/tide-predictor"
+  },
   "author": "Kevin Miller <keveemiller@gmail.com>",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
After #174, this repo now contains multiple packages (`neaps`, and `@neaps/tide-predictor`).