### PR TITLE
Remove support for `phaseKey` option in harmonic constituents.

### DIFF
--- a/packages/neaps/package.json
+++ b/packages/neaps/package.json
@@ -34,8 +34,8 @@
     "prepack": "npm run build"
   },
   "dependencies": {
+    "@neaps/tide-database": "0.2",
     "@neaps/tide-predictor": "^0.2.0",
-    "@neaps/tide-database": "0.1",
     "geolib": "^3.3.4"
   }
 }

--- a/packages/neaps/src/index.ts
+++ b/packages/neaps/src/index.ts
@@ -134,10 +134,7 @@ export function useStation(station: Station, distance?: number) {
       offset = mslOffset - datumOffset
     }
 
-    return tidePredictor(harmonic_constituents, {
-      phaseKey: 'phase_UTC',
-      offset
-    })
+    return tidePredictor(harmonic_constituents, { offset })
   }
 
   return {

--- a/packages/tide-predictor/README.md
+++ b/packages/tide-predictor/README.md
@@ -24,8 +24,7 @@ import TidePredictor from '@neaps/tide-predictor'
 
 const constituents = [
   {
-    phase_GMT: 98.7,
-    phase_local: 313.7,
+    phase: 98.7,
     amplitude: 2.687,
     name: 'M2',
     speed: 28.984104
@@ -33,9 +32,7 @@ const constituents = [
   //....there are usually many, read the docs
 ]
 
-const highLowTides = TidePredictor(constituents, {
-  phaseKey: 'phase_GMT'
-}).getExtremesPrediction({
+const highLowTides = TidePredictor(constituents).getExtremesPrediction({
   start: new Date('2019-01-01'),
   end: new Date('2019-01-10')
 })
@@ -49,7 +46,6 @@ Calling `tidePredictor` will generate a new tide prediction object. It accepts t
 
 - `constituents` - An array of [constituent objects](#constituent-object)
 - `options` - An object with one of:
-  - `phaseKey` - The name of the parameter within constituents that is considered the "phase" because many constituent datum come with multiple phases (in the case of NOAA's data, they are `phase_local` and `phase_GMT`).
   - `offset` - A value to add to **all** values predicted. This is useful if you want to, for example, offset tides by mean high water, etc.
 
 ### Tide prediction methods
@@ -146,19 +142,19 @@ Tidal constituents should be an array of objects with at least:
 
 - `name` - **string** - The NOAA constituent name, all upper-case.
 - `amplitude` - **float** - The constituent amplitude
-- `[phase]` - **float** - The phase of the constituent. Because several services provide different phase values, you can choose which one to use when building your tide prediction.
+- `phase` - **float** - The phase of the constituent.
 
-```
+```json
 [
   {
-    name: '[constituent name]',
-    amplitude: 1.3,
-    phase: 1.33
+    "name": "[constituent name]",
+    "amplitude": 1.3,
+    "phase": 1.33
   },
   {
-    name: '[constituent name 2]',
-    amplitude: 1.3,
-    phase: 1.33
+    "name": "[constituent name 2]",
+    "amplitude": 1.3,
+    "phase": 1.33
   }
 ]
 ```

--- a/packages/tide-predictor/src/harmonics/index.ts
+++ b/packages/tide-predictor/src/harmonics/index.ts
@@ -11,7 +11,6 @@ export type * from './prediction.js'
 
 export interface HarmonicsOptions {
   harmonicConstituents: HarmonicConstituent[]
-  phaseKey: string
   offset: number | false
 }
 
@@ -54,7 +53,6 @@ const getTimeline = (start: Date, end: Date, seconds: number = 10 * 60) => {
 
 const harmonicsFactory = ({
   harmonicConstituents,
-  phaseKey,
   offset
 }: HarmonicsOptions): Harmonics => {
   if (!Array.isArray(harmonicConstituents)) {
@@ -69,7 +67,7 @@ const harmonicsFactory = ({
       constituents.push({
         ...constituent,
         _model: constituentModels[constituent.name],
-        _phase: d2r * constituent[phaseKey]
+        phase: d2r * constituent.phase
       })
     }
   })
@@ -78,7 +76,7 @@ const harmonicsFactory = ({
     constituents.push({
       name: 'Z0',
       _model: constituentModels.Z0,
-      _phase: 0,
+      phase: 0,
       amplitude: offset
     })
   }

--- a/packages/tide-predictor/src/harmonics/prediction.ts
+++ b/packages/tide-predictor/src/harmonics/prediction.ts
@@ -11,13 +11,12 @@ export interface Timeline {
 export interface HarmonicConstituent {
   name: string
   amplitude: number
-  // This needs refactored to support generics with the `phaseKey` option
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any
+  phase: number
+  speed?: number
+  description?: string
 }
 
 export interface InternalHarmonicConstituent extends HarmonicConstituent {
-  _phase: number
   _model: Constituent | CompoundConstituent
 }
 
@@ -141,7 +140,7 @@ const predictionFactory = ({
 
     constituents.forEach((constituent) => {
       const amplitude = constituent.amplitude
-      const phase = constituent._phase
+      const phase = constituent.phase
       const f = modelF[constituent.name]
       const speed = modelBaseSpeed[constituent.name]
       const u = modelU[constituent.name]

--- a/packages/tide-predictor/src/index.ts
+++ b/packages/tide-predictor/src/index.ts
@@ -8,7 +8,6 @@ import type {
 } from './harmonics/prediction.js'
 
 export interface TidePredictionOptions {
-  phaseKey?: string
   offset?: number | false
 }
 
@@ -38,7 +37,6 @@ const tidePredictionFactory = (
 ): TidePrediction => {
   const harmonicsOptions = {
     harmonicConstituents: constituents,
-    phaseKey: 'phase_GMT',
     offset: false as number | false,
     ...options
   }

--- a/packages/tide-predictor/test/_mocks/constituents.ts
+++ b/packages/tide-predictor/test/_mocks/constituents.ts
@@ -4,8 +4,7 @@ export default [
     name: 'M2',
     description: 'Principal lunar semidiurnal constituent',
     amplitude: 1.61,
-    phase_GMT: 181.3,
-    phase_local: 309.4,
+    phase: 181.3,
     speed: 28.984104
   },
   {
@@ -13,8 +12,7 @@ export default [
     name: 'S2',
     description: 'Principal solar semidiurnal constituent',
     amplitude: 0.43,
-    phase_GMT: 180.1,
-    phase_local: 300.1,
+    phase: 180.1,
     speed: 30.0
   },
   {
@@ -22,8 +20,7 @@ export default [
     name: 'N2',
     description: 'Larger lunar elliptic semidiurnal constituent',
     amplitude: 0.37,
-    phase_GMT: 155.0,
-    phase_local: 287.4,
+    phase: 155.0,
     speed: 28.43973
   },
   {
@@ -31,8 +28,7 @@ export default [
     name: 'K1',
     description: 'Lunar diurnal constituent',
     amplitude: 1.2,
-    phase_GMT: 219.6,
-    phase_local: 99.2,
+    phase: 219.6,
     speed: 15.041069
   },
   {
@@ -40,8 +36,7 @@ export default [
     name: 'M4',
     description: 'Shallow water overtides of principal lunar constituent',
     amplitude: 0.0,
-    phase_GMT: 272.7,
-    phase_local: 168.9,
+    phase: 272.7,
     speed: 57.96821
   },
   {
@@ -49,8 +44,7 @@ export default [
     name: 'O1',
     description: 'Lunar diurnal constituent',
     amplitude: 0.75,
-    phase_GMT: 203.5,
-    phase_local: 91.9,
+    phase: 203.5,
     speed: 13.943035
   },
   {
@@ -58,8 +52,7 @@ export default [
     name: 'M6',
     description: 'Shallow water overtides of principal lunar constituent',
     amplitude: 0.0,
-    phase_GMT: 0.0,
-    phase_local: 0.0,
+    phase: 0.0,
     speed: 86.95232
   },
   {
@@ -67,8 +60,7 @@ export default [
     name: 'MK3',
     description: 'Shallow water terdiurnal',
     amplitude: 0.0,
-    phase_GMT: 0.0,
-    phase_local: 0.0,
+    phase: 0.0,
     speed: 44.025173
   },
   {
@@ -76,8 +68,7 @@ export default [
     name: 'S4',
     description: 'Shallow water overtides of principal solar constituent',
     amplitude: 0.0,
-    phase_GMT: 343.5,
-    phase_local: 223.5,
+    phase: 343.5,
     speed: 60.0
   },
   {
@@ -85,8 +76,7 @@ export default [
     name: 'MN4',
     description: 'Shallow water quarter diurnal constituent',
     amplitude: 0.0,
-    phase_GMT: 233.4,
-    phase_local: 134.0,
+    phase: 233.4,
     speed: 57.423832
   },
   {
@@ -94,8 +84,7 @@ export default [
     name: 'NU2',
     description: 'Larger lunar evectional constituent',
     amplitude: 0.07,
-    phase_GMT: 160.9,
-    phase_local: 292.8,
+    phase: 160.9,
     speed: 28.512583
   },
   {
@@ -103,8 +92,7 @@ export default [
     name: 'S6',
     description: 'Shallow water overtides of principal solar constituent',
     amplitude: 0.0,
-    phase_GMT: 0.0,
-    phase_local: 0.0,
+    phase: 0.0,
     speed: 90.0
   },
   {
@@ -112,8 +100,7 @@ export default [
     name: 'MU2',
     description: 'Variational constituent',
     amplitude: 0.04,
-    phase_GMT: 114.7,
-    phase_local: 250.9,
+    phase: 114.7,
     speed: 27.968208
   },
   {
@@ -121,8 +108,7 @@ export default [
     name: '2N2',
     description: 'Lunar elliptical semidiurnal second-order constituent',
     amplitude: 0.05,
-    phase_GMT: 125.4,
-    phase_local: 262.2,
+    phase: 125.4,
     speed: 27.895355
   },
   {
@@ -130,8 +116,7 @@ export default [
     name: 'OO1',
     description: 'Lunar diurnal',
     amplitude: 0.04,
-    phase_GMT: 246.4,
-    phase_local: 117.3,
+    phase: 246.4,
     speed: 16.139101
   },
   {
@@ -139,8 +124,7 @@ export default [
     name: 'LAM2',
     description: 'Smaller lunar evectional constituent',
     amplitude: 0.01,
-    phase_GMT: 213.6,
-    phase_local: 337.9,
+    phase: 213.6,
     speed: 29.455626
   },
   {
@@ -148,8 +132,7 @@ export default [
     name: 'S1',
     description: 'Solar diurnal constituent',
     amplitude: 0.03,
-    phase_GMT: 317.1,
-    phase_local: 197.1,
+    phase: 317.1,
     speed: 15.0
   },
   {
@@ -157,8 +140,7 @@ export default [
     name: 'M1',
     description: 'Smaller lunar elliptic diurnal constituent',
     amplitude: 0.04,
-    phase_GMT: 224.9,
-    phase_local: 108.9,
+    phase: 224.9,
     speed: 14.496694
   },
   {
@@ -166,8 +148,7 @@ export default [
     name: 'J1',
     description: 'Smaller lunar elliptic diurnal constituent',
     amplitude: 0.07,
-    phase_GMT: 232.3,
-    phase_local: 107.5,
+    phase: 232.3,
     speed: 15.5854435
   },
   {
@@ -175,8 +156,7 @@ export default [
     name: 'MM',
     description: 'Lunar monthly constituent',
     amplitude: 0.0,
-    phase_GMT: 0.0,
-    phase_local: 0.0,
+    phase: 0.0,
     speed: 0.5443747
   },
   {
@@ -184,8 +164,7 @@ export default [
     name: 'SSA',
     description: 'Solar semiannual constituent',
     amplitude: 0.07,
-    phase_GMT: 264.6,
-    phase_local: 263.9,
+    phase: 264.6,
     speed: 0.0821373
   },
   {
@@ -193,8 +172,7 @@ export default [
     name: 'SA',
     description: 'Solar annual constituent',
     amplitude: 0.2,
-    phase_GMT: 198.5,
-    phase_local: 198.1,
+    phase: 198.5,
     speed: 0.0410686
   },
   {
@@ -202,8 +180,7 @@ export default [
     name: 'MSF',
     description: 'Lunisolar synodic fortnightly constituent',
     amplitude: 0.0,
-    phase_GMT: 0.0,
-    phase_local: 0.0,
+    phase: 0.0,
     speed: 1.0158958
   },
   {
@@ -211,8 +188,7 @@ export default [
     name: 'MF',
     description: 'Lunisolar fortnightly constituent',
     amplitude: 0.04,
-    phase_GMT: 138.1,
-    phase_local: 129.3,
+    phase: 138.1,
     speed: 1.0980331
   },
   {
@@ -220,8 +196,7 @@ export default [
     name: 'RHO',
     description: 'Larger lunar evectional diurnal constituent',
     amplitude: 0.02,
-    phase_GMT: 197.0,
-    phase_local: 89.2,
+    phase: 197.0,
     speed: 13.471515
   },
   {
@@ -229,8 +204,7 @@ export default [
     name: 'Q1',
     description: 'Larger lunar elliptic diurnal constituent',
     amplitude: 0.13,
-    phase_GMT: 194.8,
-    phase_local: 87.5,
+    phase: 194.8,
     speed: 13.398661
   },
   {
@@ -238,8 +212,7 @@ export default [
     name: 'T2',
     description: 'Larger solar elliptic constituent',
     amplitude: 0.02,
-    phase_GMT: 165.3,
-    phase_local: 285.6,
+    phase: 165.3,
     speed: 29.958933
   },
   {
@@ -247,8 +220,7 @@ export default [
     name: 'R2',
     description: 'Smaller solar elliptic constituent',
     amplitude: 0.0,
-    phase_GMT: 163.2,
-    phase_local: 282.9,
+    phase: 163.2,
     speed: 30.041067
   },
   {
@@ -256,8 +228,7 @@ export default [
     name: '2Q1',
     description: 'Larger elliptic diurnal',
     amplitude: 0.02,
-    phase_GMT: 191.7,
-    phase_local: 88.8,
+    phase: 191.7,
     speed: 12.854286
   },
   {
@@ -265,8 +236,7 @@ export default [
     name: 'P1',
     description: 'Solar diurnal constituent',
     amplitude: 0.38,
-    phase_GMT: 215.8,
-    phase_local: 96.1,
+    phase: 215.8,
     speed: 14.958931
   },
   {
@@ -274,8 +244,7 @@ export default [
     name: '2SM2',
     description: 'Shallow water semidiurnal constituent',
     amplitude: 0.0,
-    phase_GMT: 348.1,
-    phase_local: 99.9,
+    phase: 348.1,
     speed: 31.015896
   },
   {
@@ -283,8 +252,7 @@ export default [
     name: 'M3',
     description: 'Lunar terdiurnal constituent',
     amplitude: 0.01,
-    phase_GMT: 7.0,
-    phase_local: 19.1,
+    phase: 7.0,
     speed: 43.47616
   },
   {
@@ -292,8 +260,7 @@ export default [
     name: 'L2',
     description: 'Smaller lunar elliptic semidiurnal constituent',
     amplitude: 0.04,
-    phase_GMT: 213.4,
-    phase_local: 337.1,
+    phase: 213.4,
     speed: 29.528479
   },
   {
@@ -301,8 +268,7 @@ export default [
     name: '2MK3',
     description: 'Shallow water terdiurnal constituent',
     amplitude: 0.0,
-    phase_GMT: 126.8,
-    phase_local: 143.4,
+    phase: 126.8,
     speed: 42.92714
   },
   {
@@ -310,8 +276,7 @@ export default [
     name: 'K2',
     description: 'Lunisolar semidiurnal constituent',
     amplitude: 0.12,
-    phase_GMT: 170.6,
-    phase_local: 289.9,
+    phase: 170.6,
     speed: 30.082138
   },
   {
@@ -319,8 +284,7 @@ export default [
     name: 'M8',
     description: 'Shallow water eighth diurnal constituent',
     amplitude: 0.0,
-    phase_GMT: 0.0,
-    phase_local: 0.0,
+    phase: 0.0,
     speed: 115.93642
   },
   {
@@ -328,8 +292,7 @@ export default [
     name: 'MS4',
     description: 'Shallow water quarter diurnal constituent',
     amplitude: 0.0,
-    phase_GMT: 264.0,
-    phase_local: 152.1,
+    phase: 264.0,
     speed: 58.984104
   }
 ]

--- a/packages/tide-predictor/test/harmonics/index.test.ts
+++ b/packages/tide-predictor/test/harmonics/index.test.ts
@@ -19,8 +19,7 @@ describe('harmonics', () => {
           {
             description: 'Missing name property',
             amplitude: 0.43,
-            phase_GMT: 180.1,
-            phase_local: 309.4
+            phase: 180.1
           }
         ]
       })
@@ -28,23 +27,20 @@ describe('harmonics', () => {
 
     expect(() => {
       harmonics({
-        phaseKey: 'phase_GMT',
         offset: 0,
         harmonicConstituents: [
           {
             name: 'not a name',
             description: 'Principal lunar semidiurnal constituent',
             amplitude: 1.61,
-            phase_GMT: 181.3,
-            phase_local: 309.4,
+            phase: 181.3,
             speed: 28.984104
           },
           {
             name: 'M2',
             description: 'Principal solar semidiurnal constituent',
             amplitude: 0.43,
-            phase_GMT: 180.1,
-            phase_local: 309.4
+            phase: 180.1
           }
         ]
       })
@@ -53,7 +49,6 @@ describe('harmonics', () => {
 
   it('it checks start and end times', () => {
     const testHarmonics = harmonics({
-      phaseKey: 'phase_GMT',
       offset: 0,
       harmonicConstituents: mockHarmonicConstituents
     })

--- a/packages/tide-predictor/test/harmonics/prediction.test.ts
+++ b/packages/tide-predictor/test/harmonics/prediction.test.ts
@@ -9,7 +9,6 @@ const extremesEndDate = new Date('2019-09-03T00:00:00Z')
 const setUpPrediction = () => {
   const harmonic = harmonics({
     harmonicConstituents: mockHarmonicConstituents,
-    phaseKey: 'phase_GMT',
     offset: false
   })
   harmonic.setTimeSpan(startDate, endDate)
@@ -25,24 +24,9 @@ describe('harmonic prediction', () => {
     expect(lastResult?.level).toBeCloseTo(2.85263589, 3)
   })
 
-  it('it creates a timeline prediction with a non-default phase key', () => {
-    const results = harmonics({
-      harmonicConstituents: mockHarmonicConstituents,
-      phaseKey: 'phase_local',
-      offset: false
-    })
-      .setTimeSpan(startDate, endDate)
-      .prediction()
-      .getTimelinePrediction()
-    expect(results[0].level).toBeCloseTo(2.7560979, 3)
-    const lastPhaseResult = results.pop()
-    expect(lastPhaseResult?.level).toBeCloseTo(-2.9170977, 3)
-  })
-
   it('it finds high and low tides', () => {
     const results = harmonics({
       harmonicConstituents: mockHarmonicConstituents,
-      phaseKey: 'phase_GMT',
       offset: false
     })
       .setTimeSpan(startDate, extremesEndDate)
@@ -57,7 +41,6 @@ describe('harmonic prediction', () => {
 
     const labelResults = harmonics({
       harmonicConstituents: mockHarmonicConstituents,
-      phaseKey: 'phase_GMT',
       offset: false
     })
       .setTimeSpan(startDate, extremesEndDate)
@@ -69,7 +52,6 @@ describe('harmonic prediction', () => {
   it('it finds high and low tides with high fidelity', () => {
     const results = harmonics({
       harmonicConstituents: mockHarmonicConstituents,
-      phaseKey: 'phase_GMT',
       offset: false
     })
       .setTimeSpan(startDate, extremesEndDate)
@@ -82,7 +64,6 @@ describe('harmonic prediction', () => {
 describe('Secondary stations', () => {
   const regularResults = harmonics({
     harmonicConstituents: mockHarmonicConstituents,
-    phaseKey: 'phase_GMT',
     offset: false
   })
     .setTimeSpan(startDate, extremesEndDate)
@@ -104,7 +85,6 @@ describe('Secondary stations', () => {
 
     const offsetResults = harmonics({
       harmonicConstituents: mockHarmonicConstituents,
-      phaseKey: 'phase_GMT',
       offset: false
     })
       .setTimeSpan(startDate, extremesEndDate)
@@ -148,7 +128,6 @@ describe('Secondary stations', () => {
 
     const offsetResults = harmonics({
       harmonicConstituents: mockHarmonicConstituents,
-      phaseKey: 'phase_GMT',
       offset: false
     })
       .setTimeSpan(startDate, extremesEndDate)


### PR DESCRIPTION
After #183 and https://github.com/neaps/tide-database/pull/33, this removes the `phaseKey` option because phases are now always relative to UTC.