### PR TITLE
Alias SGM/SIGMA1, refactor aliasing.

### DIFF
--- a/packages/tide-predictor/src/constituents/LAM2.ts
+++ b/packages/tide-predictor/src/constituents/LAM2.ts
@@ -1,8 +1,0 @@
-import LAMBDA2 from "./LAMBDA2.js";
-
-/**
- * Alias for compatibility between NOAA and IHO
- *
- * @see LAMBDA2
- */
-export default LAMBDA2;

--- a/packages/tide-predictor/src/constituents/LAMBDA2.ts
+++ b/packages/tide-predictor/src/constituents/LAMBDA2.ts
@@ -7,4 +7,4 @@ import nc from "../node-corrections/index.js";
  * Amplitude typically <5% of M2; important in detailed constituent analysis.
  * IHO standard designation (previously abbreviated as LAM2).
  */
-export default defineConstituent("LAMBDA2", [2, 1, -2, 1, 0, 0, 2], nc.uM2, nc.fM2);
+export default defineConstituent(["LAM2", "LAMBDA2"], [2, 1, -2, 1, 0, 0, 2], nc.uM2, nc.fM2);

--- a/packages/tide-predictor/src/constituents/RHO.ts
+++ b/packages/tide-predictor/src/constituents/RHO.ts
@@ -1,8 +1,0 @@
-import RHO1 from "./RHO1.js";
-
-/**
- * Alias for compatibility between NOAA and IHO
- *
- * @see RHO1
- */
-export default RHO1;

--- a/packages/tide-predictor/src/constituents/RHO1.ts
+++ b/packages/tide-predictor/src/constituents/RHO1.ts
@@ -9,7 +9,10 @@ import K1 from "./K1.js";
  * Amplitude typically very small; rarely significant.
  * Found only in shallow-water regions with strong tidal distortion.
  */
-export default defineCompoundConstituent("RHO1", [
-  { constituent: NU2, factor: 1 },
-  { constituent: K1, factor: -1 },
-]);
+export default defineCompoundConstituent(
+  ["RHO", "RHO1"],
+  [
+    { constituent: NU2, factor: 1 },
+    { constituent: K1, factor: -1 },
+  ],
+);

--- a/packages/tide-predictor/src/constituents/SA.ts
+++ b/packages/tide-predictor/src/constituents/SA.ts
@@ -5,4 +5,4 @@ import nc from "../node-corrections/index.js";
  * Solar annual (Sa).
  * Long-term constituent driven by solar declination variations over the year.
  */
-export default defineConstituent("Sa", [0, 0, 1, 0, 0, 0, 0], nc.uZero, nc.fUnity);
+export default defineConstituent(["SA", "Sa"], [0, 0, 1, 0, 0, 0, 0], nc.uZero, nc.fUnity);

--- a/packages/tide-predictor/src/constituents/SGM.ts
+++ b/packages/tide-predictor/src/constituents/SGM.ts
@@ -7,4 +7,4 @@ import nc from "../node-corrections/index.js";
  *
  * Note: Often has small amplitude; closely related to K1 and O1 variations.
  */
-export default defineConstituent("SGM", [1, -3, 2, 0, 0, 0, -1], nc.uO1, nc.fO1);
+export default defineConstituent(["SGM", "SIGMA1"], [1, -3, 2, 0, 0, 0, -1], nc.uO1, nc.fO1);

--- a/packages/tide-predictor/src/constituents/SSA.ts
+++ b/packages/tide-predictor/src/constituents/SSA.ts
@@ -5,4 +5,4 @@ import nc from "../node-corrections/index.js";
  * Solar semi-annual (Ssa).
  * Semi-annual constituent from solar declination with twice-yearly periodicity.
  */
-export default defineConstituent("Ssa", [0, 0, 2, 0, 0, 0, 0], nc.uZero, nc.fUnity);
+export default defineConstituent(["Ssa", "SSA"], [0, 0, 2, 0, 0, 0, 0], nc.uZero, nc.fUnity);

--- a/packages/tide-predictor/src/constituents/definition.ts
+++ b/packages/tide-predictor/src/constituents/definition.ts
@@ -2,7 +2,7 @@ import type { AstroData } from "../astronomy/index.js";
 import nodeCorrections, { type NodeCorrectionFunction } from "../node-corrections/index.js";
 
 export interface Constituent {
-  name: string;
+  names: string[];
   coefficients: number[];
   value: (astro: AstroData) => number;
   speed: (astro: AstroData) => number;
@@ -11,7 +11,7 @@ export interface Constituent {
 }
 
 export function defineConstituent(
-  name: string,
+  names: string | string[],
   coefficients: number[],
   u?: NodeCorrectionFunction,
   f?: NodeCorrectionFunction,
@@ -21,7 +21,8 @@ export function defineConstituent(
   }
 
   return Object.freeze({
-    name,
+    names: Array.isArray(names) ? names : [names],
+
     coefficients,
 
     value: (astro: AstroData): number => {
@@ -43,7 +44,10 @@ export interface ConstituentMember {
   factor: number;
 }
 
-export function defineCompoundConstituent(name: string, members: ConstituentMember[]): Constituent {
+export function defineCompoundConstituent(
+  names: string | string[],
+  members: ConstituentMember[],
+): Constituent {
   const coefficients: number[] = [];
   members.forEach(({ constituent, factor }) => {
     constituent.coefficients.forEach((coefficient, index) => {
@@ -55,7 +59,7 @@ export function defineCompoundConstituent(name: string, members: ConstituentMemb
   });
 
   return Object.freeze({
-    name,
+    names: Array.isArray(names) ? names : [names],
     coefficients,
 
     speed: (astro: AstroData): number => {

--- a/packages/tide-predictor/src/constituents/index.ts
+++ b/packages/tide-predictor/src/constituents/index.ts
@@ -10,16 +10,12 @@ const constituents: Record<string, Constituent> = {};
 
 // Extract constituent name from file path and populate the constituents object
 for (const [path, module] of Object.entries(constituentModules)) {
-  // Skip the index file itself
-  if (path.includes("index.ts")) continue;
+  // Skip the index and definition files
+  if (path.match(/index|definition/)) continue;
 
-  // Extract filename without extension and .js suffix
-  const name = path.split("/").pop()?.replace(/\..*$/, "") ?? "";
-
-  // Skip module for definition.ts
-  if (name === "definition") continue;
-
-  constituents[name] = module;
+  module.names.forEach((name) => {
+    constituents[name] = module;
+  });
 }
 
 export default constituents;


### PR DESCRIPTION
Adds `SIGMA1` as an alias for the existing `SGM` constituent. This also refactors constituent definitions to just allow specifying all names as part of the definition instead of creating a separate file that imports the existing definition.

cc https://github.com/neaps/tide-database/pull/16