### PR TITLE
Update tests for tide-database internal id change

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ console.log(timeline);
 //   datum: 'MLLW',
 //   units: 'meters',
 //   station: {
-//     id: 'us-fl-port-of-west-palm-beach',
-//     name: 'Port of West Palm Beach',
+//     id: 'noaa/8722588',
+//     name: 'Port of Palm Beach',
 //     // ...
 //   },
 //   timeline: [
@@ -99,8 +99,8 @@ console.log(prediction);
 //   datum: 'MSL',
 //   units: 'meters',
 //   station: {
-//     id: 'us-fl-port-of-west-palm-beach',
-//     name: 'Port of West Palm Beach',
+//     id: 'noaa/8722588',
+//     name: 'Port of Palm Beach',
 //     // ...
 //   },
 //   time: 2025-12-19T05:30:00.000Z,
@@ -162,7 +162,7 @@ stationsNear({ latitude: 45.6, longitude: -122.7 }, 5).forEach((s) => {
 import { findStation } from "neaps";
 
 // Find station by Neaps ID
-findStation("us-wa-seattle"); // Seattle
+findStation("noaa/8443970"); // Boston
 
 // Find station by source ID (e.g. NOAA)
 findStation("9440083"); // Vancouver

--- a/examples/stations.ts
+++ b/examples/stations.ts
@@ -11,7 +11,7 @@ console.log(
 );
 
 // Find station by Neaps ID
-findStation("us/ma/boston"); // Boston
+findStation("noaa/8443970"); // Boston
 
 // Find station by source ID (e.g. NOAA)
 findStation("9440083"); // Vancouver

--- a/packages/neaps/package.json
+++ b/packages/neaps/package.json
@@ -34,8 +34,8 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@neaps/tide-database": "0.2",
-    "@neaps/tide-predictor": "^0.3.0",
+    "@neaps/tide-database": "0.3",
+    "@neaps/tide-predictor": "^0.4.0",
     "geolib": "^3.3.4"
   }
 }

--- a/packages/neaps/test/index.test.ts
+++ b/packages/neaps/test/index.test.ts
@@ -66,7 +66,7 @@ describe("getExtremesPrediction", () => {
   test("gets extremes from nearest station", () => {
     const prediction = getExtremesPrediction(options);
 
-    expect(prediction.station.id).toEqual("us/fl/port-of-palm-beach");
+    expect(prediction.station.id).toEqual("noaa/8722588");
     expect(prediction.datum).toBe("MLLW");
 
     const { extremes } = prediction;
@@ -96,7 +96,7 @@ describe("getTimelinePrediction", () => {
       end: new Date("2025-12-19T01:00:00-05:00"),
     });
 
-    expect(prediction.station.id).toEqual("us/fl/port-of-palm-beach");
+    expect(prediction.station.id).toEqual("noaa/8722588");
     expect(prediction.datum).toBe("MLLW");
     expect(prediction.units).toBe("meters");
     expect(prediction.timeline.length).toBe(7); // Every 10 minutes for 1 hour = 7 points
@@ -124,7 +124,7 @@ describe("getWaterLevelAtTime", () => {
       datum: "MSL",
     });
 
-    expect(prediction.station.id).toEqual("us/fl/port-of-palm-beach");
+    expect(prediction.station.id).toEqual("noaa/8722588");
     expect(prediction.datum).toBe("MSL");
     expect(prediction.time).toEqual(new Date("2025-12-19T05:30:00.000Z"));
     expect(typeof prediction.level).toBe("number");
@@ -291,16 +291,16 @@ describe("findStation", () => {
   });
 
   test("finds station by id", () => {
-    const station = findStation("us/ma/boston");
+    const station = findStation("noaa/8443970");
     expect(station).toBeDefined();
-    expect(station.id).toBe("us/ma/boston");
+    expect(station.source.id).toBe("8443970");
     expect(station.getExtremesPrediction).toBeDefined();
   });
 
   test("finds station by source id", () => {
     const station = findStation("8443970");
     expect(station).toBeDefined();
-    expect(station.id).toBe("us/ma/boston");
+    expect(station.id).toBe("noaa/8443970");
     expect(station.getExtremesPrediction).toBeDefined();
   });
 });
@@ -326,7 +326,7 @@ describe("datum", () => {
   });
 
   test("throws error for unavailable datum", () => {
-    const station = findStation("us/ma/boston");
+    const station = findStation("noaa/8443970");
     expect(() => {
       station.getExtremesPrediction({
         start: new Date("2025-12-17T00:00:00Z"),


### PR DESCRIPTION
Companion to https://github.com/neaps/tide-database/pull/37

- [x] Update @neaps/tide-database dependency after it is released