### PR TITLE
Use Temporal

### DIFF
--- a/benchmarks/noaa.ts
+++ b/benchmarks/noaa.ts
@@ -76,7 +76,7 @@ for (const id of stations) {
       end,
     })
     .extremes.map((e) => ({
-      time: e.time.getTime(),
+      time: e.time.epochMilliseconds,
       level: e.level,
       type: e.high ? "H" : "L",
     }));

--- a/examples/temporal-example.ts
+++ b/examples/temporal-example.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Example demonstrating Temporal.Instant support in Neaps
+ * Run with: node examples/temporal-example.mjs
+ */
+
+import { Temporal } from "@js-temporal/polyfill";
+import { getExtremesPrediction } from "neaps";
+
+// Example 1: Using JavaScript Date (backward compatible)
+console.log("=== Using JavaScript Date ===");
+const predictionWithDate = getExtremesPrediction({
+  lat: 26.772,
+  lon: -80.05,
+  start: new Date("2025-12-18T00:00:00Z"),
+  end: new Date("2025-12-19T00:00:00Z"),
+  datum: "MLLW",
+});
+
+console.log("Extremes found:", predictionWithDate.extremes.length);
+console.log("First extreme:", {
+  time: predictionWithDate.extremes[0].time.toString(),
+  level: predictionWithDate.extremes[0].level.toFixed(2),
+  type: predictionWithDate.extremes[0].high ? "High" : "Low",
+});
+
+// Example 2: Using Temporal.Instant (native Temporal support)
+console.log("\n=== Using Temporal.Instant ===");
+const startInstant = Temporal.Instant.from("2025-12-18T00:00:00Z");
+const endInstant = Temporal.Instant.from("2025-12-19T00:00:00Z");
+
+const predictionWithTemporal = getExtremesPrediction({
+  lat: 26.772,
+  lon: -80.05,
+  start: startInstant,
+  end: endInstant,
+  datum: "MLLW",
+});
+
+console.log("Extremes found:", predictionWithTemporal.extremes.length);
+console.log("First extreme:", {
+  time: predictionWithTemporal.extremes[0].time.toString(),
+  level: predictionWithTemporal.extremes[0].level.toFixed(2),
+  type: predictionWithTemporal.extremes[0].high ? "High" : "Low",
+});
+
+// Example 3: Converting returned Temporal.Instant to Date
+console.log("\n=== Converting Temporal.Instant back to Date ===");
+const instant = predictionWithTemporal.extremes[0].time;
+const date = new Date(instant.epochMilliseconds);
+console.log("As Date object:", date.toISOString());
+console.log("As Date string:", date.toString());
+
+// Example 4: Using Temporal for manipulation
+console.log("\n=== Temporal API benefits ===");
+const timeOfExtreme = predictionWithTemporal.extremes[0].time;
+const oneHourLater = timeOfExtreme.add({ hours: 1 });
+const oneHourEarlier = timeOfExtreme.subtract({ hours: 1 });
+
+console.log("One hour earlier:", oneHourEarlier.toString());
+console.log("Extreme time:", timeOfExtreme.toString());
+console.log("One hour later:", oneHourLater.toString());

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@neaps/tide-database": "*",
     "@types/make-fetch-happen": "^10.0.4",
     "@types/node": "^25.0.2",
     "@vitest/coverage-v8": "^4.0.15",

--- a/packages/neaps/package.json
+++ b/packages/neaps/package.json
@@ -34,6 +34,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
+    "@js-temporal/polyfill": "^0.5",
     "@neaps/tide-database": "0.3",
     "@neaps/tide-predictor": "^0.4.0",
     "geolib": "^3.3.4"

--- a/packages/neaps/test/index.test.ts
+++ b/packages/neaps/test/index.test.ts
@@ -43,7 +43,7 @@ describe("timezone independence", () => {
       expect(result.length).toBe(baseline.length);
       result.forEach((extreme, index) => {
         const base = baseline[index];
-        expect(extreme.time.valueOf()).toBe(base.time.valueOf());
+        expect(extreme.time.epochMilliseconds).toBe(base.time.epochMilliseconds);
         expect(extreme.high).toBe(base.high);
         expect(extreme.low).toBe(base.low);
         expect(extreme.label).toBe(base.label);
@@ -71,7 +71,9 @@ describe("getExtremesPrediction", () => {
 
     const { extremes } = prediction;
     expect(extremes.length).toBe(4);
-    expect(extremes[0].time).toEqual(new Date("2025-12-18T05:30:00.000Z"));
+    expect(extremes[0].time.epochMilliseconds).toEqual(
+      new Date("2025-12-18T05:30:00.000Z").getTime(),
+    );
     expect(extremes[0].level).toBeCloseTo(0.02, 2);
     expect(extremes[0].high).toBe(false);
     expect(extremes[0].low).toBe(true);
@@ -126,7 +128,9 @@ describe("getWaterLevelAtTime", () => {
 
     expect(prediction.station.id).toEqual("noaa/8722588");
     expect(prediction.datum).toBe("MSL");
-    expect(prediction.time).toEqual(new Date("2025-12-19T05:30:00.000Z"));
+    expect(prediction.time.epochMilliseconds).toEqual(
+      new Date("2025-12-19T05:30:00.000Z").getTime(),
+    );
     expect(typeof prediction.level).toBe("number");
   });
 
@@ -173,7 +177,9 @@ describe("for a specific station", () => {
       });
 
       expect(predictions.length).toBe(4);
-      expect(predictions[0].time).toEqual(new Date("2025-12-17T11:23:00.000Z"));
+      expect(predictions[0].time.epochMilliseconds).toEqual(
+        new Date("2025-12-17T11:23:00.000Z").getTime(),
+      );
       expect(predictions[0].level).toBeCloseTo(0.9, 1);
       expect(predictions[0].high).toBe(true);
       expect(predictions[0].low).toBe(false);
@@ -221,7 +227,10 @@ describe("for a specific station", () => {
 
         noaa.forEach((expected, index) => {
           const actual = prediction.extremes[index];
-          expect(actual.time).toBeWithin(new Date(expected.t).valueOf(), 5 * 60 * 1000 /* min */);
+          expect(actual.time.epochMilliseconds).toBeWithin(
+            new Date(expected.t).getTime(),
+            5 * 60 * 1000 /* min */,
+          );
           expect(actual.level).toBeWithin(expected.v, 0.04 /* m */);
         });
       });
@@ -265,7 +274,7 @@ describe("for a specific station", () => {
       const prediction = station.getWaterLevelAtTime({
         time: new Date("2025-12-19T00:30:00Z"),
       });
-      expect(prediction.time).toEqual(new Date("2025-12-19T00:30:00Z"));
+      expect(prediction.time.epochMilliseconds).toEqual(new Date("2025-12-19T00:30:00Z").getTime());
       expect(prediction.datum).toBe("MLLW");
       expect(typeof prediction.level).toBe("number");
     });

--- a/packages/tide-predictor/package.json
+++ b/packages/tide-predictor/package.json
@@ -21,9 +21,11 @@
   "files": [
     "dist"
   ],
-  "devDependencies": {},
   "scripts": {
     "build": "tsdown",
     "prepack": "npm run build"
+  },
+  "dependencies": {
+    "@js-temporal/polyfill": "^0.5"
   }
 }

--- a/packages/tide-predictor/src/harmonics/prediction.ts
+++ b/packages/tide-predictor/src/harmonics/prediction.ts
@@ -1,9 +1,10 @@
+import { Temporal } from "@js-temporal/polyfill";
 import astro from "../astronomy/index.js";
 import { d2r } from "../astronomy/constants.js";
 import constituentModels from "../constituents/index.js";
 
 export interface Timeline {
-  items: Date[];
+  items: Temporal.Instant[];
   hours: number[];
 }
 
@@ -16,13 +17,13 @@ export interface HarmonicConstituent {
 }
 
 export interface TimelinePoint {
-  time: Date;
+  time: Temporal.Instant;
   hour: number;
   level: number;
 }
 
 export interface Extreme {
-  time: Date;
+  time: Temporal.Instant;
   level: number;
   high: boolean;
   low: boolean;
@@ -80,10 +81,10 @@ const addExtremesOffsets = (extreme: Extreme, offsets?: ExtremeOffsets): Extreme
     }
   }
   if (extreme.high && offsets.time?.high) {
-    extreme.time = new Date(extreme.time.getTime() + offsets.time.high * 60 * 1000);
+    extreme.time = extreme.time.add({ milliseconds: offsets.time.high * 60 * 1000 });
   }
   if (extreme.low && offsets.time?.low) {
-    extreme.time = new Date(extreme.time.getTime() + offsets.time.low * 60 * 1000);
+    extreme.time = extreme.time.add({ milliseconds: offsets.time.low * 60 * 1000 });
   }
   return extreme;
 };
@@ -102,7 +103,7 @@ const getExtremeLabel = (label: "high" | "low", highLowLabels?: ExtremeLabels): 
 interface PredictionFactoryParams {
   timeline: Timeline;
   constituents: HarmonicConstituent[];
-  start: Date;
+  start: Temporal.Instant;
 }
 
 const predictionFactory = ({
@@ -142,6 +143,7 @@ const predictionFactory = ({
     const { labels, offsets } = typeof options !== "undefined" ? options : {};
     const results: Extreme[] = [];
     const { baseSpeed, u, f, baseValue } = prepare();
+
     let goingUp = false;
     let goingDown = false;
     let lastLevel = getLevel(0, baseSpeed, u[0], f[0], baseValue);

--- a/packages/tide-predictor/test/harmonics/index.test.ts
+++ b/packages/tide-predictor/test/harmonics/index.test.ts
@@ -1,9 +1,10 @@
+import { Temporal } from "@js-temporal/polyfill";
 import { describe, it, expect } from "vitest";
-import harmonics, { getDate, getTimeline } from "../../src/harmonics/index.js";
+import harmonics, { getInstant, getTimeline } from "../../src/harmonics/index.js";
 import mockHarmonicConstituents from "../_mocks/constituents.js";
 
-const startDate = new Date(1567346400 * 1000); // 2019-09-01
-const endDate = new Date(1569966078 * 1000); // 2019-10-01
+const startDate = Temporal.Instant.fromEpochMilliseconds(1567346400 * 1000); // 2019-09-01
+const endDate = Temporal.Instant.fromEpochMilliseconds(1569966078 * 1000); // 2019-10-01
 
 describe("harmonics", () => {
   it("it checks constituents", () => {
@@ -55,7 +56,7 @@ describe("harmonics", () => {
     expect(() => {
       // @ts-expect-error: Testing invalid input
       testHarmonics.setTimeSpan("lkjsdlf", "sdfklj");
-    }).toThrow("Invalid date format, should be a Date object, or timestamp");
+    }).toThrow("Invalid date format, should be a Date, Temporal.Instant, or timestamp");
 
     expect(() => {
       testHarmonics.setTimeSpan(startDate, startDate);
@@ -67,17 +68,16 @@ describe("harmonics", () => {
   });
 
   it("it parses dates correctly", () => {
-    const parsedDate = getDate(startDate);
-    expect(parsedDate.getTime()).toBe(startDate.getTime());
+    const parsedDate = getInstant(startDate);
+    expect(parsedDate.epochMilliseconds).toBe(startDate.epochMilliseconds);
 
-    const parsedUnixDate = getDate(startDate.getTime() / 1000);
-    expect(parsedUnixDate.getTime()).toBe(startDate.getTime());
+    const parsedUnixDate = getInstant(startDate.epochMilliseconds / 1000);
+    expect(parsedUnixDate.epochMilliseconds).toBe(startDate.epochMilliseconds);
   });
 
   it("it creates timeline correctly", () => {
     const seconds = 20 * 60;
-    const difference =
-      Math.round((endDate.getTime() / 1000 - startDate.getTime() / 1000) / seconds) + 1;
+    const difference = Math.round(endDate.since(startDate).total("seconds") / seconds) + 1;
     const { items, hours } = getTimeline(startDate, endDate, seconds);
     expect(items.length).toBe(difference);
     expect(hours.length).toBe(difference);

--- a/packages/tide-predictor/test/harmonics/prediction.test.ts
+++ b/packages/tide-predictor/test/harmonics/prediction.test.ts
@@ -97,8 +97,8 @@ describe("Secondary stations", () => {
           regularResults[index].level * offsets.height!.low!,
           4,
         );
-        expect(offsetResult.time.getTime()).toBe(
-          regularResults[index].time.getTime() + offsets.time!.low! * 60 * 1000,
+        expect(offsetResult.time.epochMilliseconds).toBe(
+          regularResults[index].time.epochMilliseconds + offsets.time!.low! * 60 * 1000,
         );
       }
       if (offsetResult.high) {
@@ -107,8 +107,8 @@ describe("Secondary stations", () => {
           4,
         );
 
-        expect(offsetResult.time.getTime()).toBe(
-          regularResults[index].time.getTime() + offsets.time!.high! * 60 * 1000,
+        expect(offsetResult.time.epochMilliseconds).toBe(
+          regularResults[index].time.epochMilliseconds + offsets.time!.high! * 60 * 1000,
         );
       }
     });
@@ -140,8 +140,8 @@ describe("Secondary stations", () => {
           regularResults[index].level + offsets.height!.low!,
           4,
         );
-        expect(offsetResult.time.getTime()).toBe(
-          regularResults[index].time.getTime() + offsets.time!.low! * 60 * 1000,
+        expect(offsetResult.time.epochMilliseconds).toBe(
+          regularResults[index].time.epochMilliseconds + offsets.time!.low! * 60 * 1000,
         );
       }
       if (offsetResult.high) {
@@ -150,8 +150,8 @@ describe("Secondary stations", () => {
           4,
         );
 
-        expect(offsetResult.time.getTime()).toBe(
-          regularResults[index].time.getTime() + offsets.time!.high! * 60 * 1000,
+        expect(offsetResult.time.epochMilliseconds).toBe(
+          regularResults[index].time.epochMilliseconds + offsets.time!.high! * 60 * 1000,
         );
       }
     });


### PR DESCRIPTION
The [Temporal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) API is nearing completion and has many advantages of `Date`, especially with Timezone handling.

This is an experiment to switch to it. I'm not sure yet if I'm going to merge this. All methods accept a `Date` or `Temporal.Instant`. 

TODO:
- [ ] Update READMEs
- [ ] Should the `get*Prediction` methods return `Date|Temporal.Instant` depending on what was passed to it?
- [ ] The `JD` calculation still uses `Date` because performance was horrible when using a `Temporal.PlainDateTime`. 