### PR TITLE
Publish all commits to GitHub Package Registry

### DIFF
--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -1,0 +1,23 @@
+name: Cleanup Packages
+
+on:
+  schedule:
+    # Run weekly on Sundays at 2am UTC
+    - cron: "0 2 * * 0"
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        package: [tide-predictor, neaps, api]
+    steps:
+      - uses: actions/delete-package-versions@v5
+        with:
+          package-name: ${{ matrix.package }}
+          package-type: npm
+          min-versions-to-keep: 30
+          delete-only-pre-release-versions: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,19 +59,3 @@ jobs:
           npm pkg delete dependencies.neaps
           npm publish --access public --tag "$TAG"
           cd ../..
-
-  cleanup:
-    runs-on: ubuntu-latest
-    needs: publish
-    permissions:
-      packages: write
-    strategy:
-      matrix:
-        package: [tide-predictor, neaps, api]
-    steps:
-      - uses: actions/delete-package-versions@v5
-        with:
-          package-name: ${{ matrix.package }}
-          package-type: npm
-          min-versions-to-keep: 30
-          delete-only-pre-release-versions: true


### PR DESCRIPTION
This adds an action to publish all packages to the GitHub Package Registry on push/PR. This is just to make it easier to test out branches or unreleased changes. Only the 30 most recent releases will be kept.