### PR TITLE
Fix incorrect division for milleseconds in JD function

### DIFF
--- a/.changeset/millesecond-fix.md
+++ b/.changeset/millesecond-fix.md
@@ -1,0 +1,5 @@
+---
+"@neaps/tide-predictor": patch
+---
+
+Fix incorrect division for milleseconds in JD function (Thanks @dartheditous)

--- a/packages/tide-predictor/src/astronomy/index.ts
+++ b/packages/tide-predictor/src/astronomy/index.ts
@@ -56,7 +56,7 @@ const JD = (t: Date): number => {
     t.getUTCHours() / 24.0 +
     t.getUTCMinutes() / (24.0 * 60.0) +
     t.getUTCSeconds() / (24.0 * 60.0 * 60.0) +
-    t.getUTCMilliseconds() / (24.0 * 60.0 * 60.0 * 1e6);
+    t.getUTCMilliseconds() / (24.0 * 60.0 * 60.0 * 1e3);
   if (M <= 2) {
     Y = Y - 1;
     M = M + 12;

--- a/packages/tide-predictor/test/constituents/index.test.ts
+++ b/packages/tide-predictor/test/constituents/index.test.ts
@@ -15,7 +15,7 @@ describe("Base constituent definitions", () => {
   });
 
   it("it prepared constituent M2", () => {
-    expect(constituents.M2.value(testAstro)).toBeCloseTo(537.008710124, 4);
+    expect(constituents.M2.value(testAstro)).toBeCloseTo(537.008790781, 4);
   });
 
   it("computes IHO nodal corrections for M2", () => {


### PR DESCRIPTION
Thanks @dartheditous

Fixes #256 