### PR TITLE
Add CHS benchmark for Canadian TICON stations

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,51 @@
+name: Benchmarks
+on:
+  workflow_call:
+  workflow_dispatch:
+  schedule:
+    # Re-run against fresh NOAA/CHS predictions monthly, even without pushes.
+    - cron: "23 6 2 * *"
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: benchmarks-${{ github.ref }}-${{ github.event_name }}
+      cancel-in-progress: true
+    env:
+      FAST: ${{ github.ref != 'refs/heads/main' && 'true' || '' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install modules
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Compute cache month
+        id: month
+        run: echo "month=$(date -u +%Y-%m)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache benchmark data
+        id: benchmark-cache
+        uses: actions/cache@v5
+        with:
+          path: .test-cache
+          # Month-stamped so cached reference predictions roll over and the
+          # scheduled run compares against fresh data.
+          key: benchmarks-${{ env.FAST }}-${{ steps.month.outputs.month }}-${{ hashFiles('benchmarks/*.ts') }}
+
+      - name: Run benchmarks
+        run: npm run benchmarks
+
+      - name: Upload benchmark results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmarks
+          path: benchmarks/*.csv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,40 +88,7 @@ jobs:
         run: npx pkg-pr-new publish ./packages/*
 
   benchmarks:
-    runs-on: ubuntu-latest
-    concurrency:
-      group: benchmarks-${{ github.ref }}
-      cancel-in-progress: true
-    env:
-      FAST: ${{ github.ref != 'refs/heads/main' && 'true' || '' }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-
-      - name: Install modules
-        run: npm install
-
-      - name: Build
-        run: npm run build
-
-      - name: Cache benchmark data
-        id: benchmark-cache
-        uses: actions/cache@v5
-        with:
-          path: .test-cache
-          key: benchmarks-${{ env.FAST }}-${{ hashFiles('benchmarks/noaa.ts') }}
-
-      - name: Run benchmarks
-        run: npm run benchmarks
-
-      - name: Upload benchmark results
-        uses: actions/upload-artifact@v7
-        with:
-          name: benchmarks
-          path: benchmarks/*.csv
+    uses: ./.github/workflows/benchmarks.yml
 
   examples:
     runs-on: ubuntu-latest

--- a/benchmarks/chs.ts
+++ b/benchmarks/chs.ts
@@ -1,0 +1,344 @@
+import { expect } from "vitest";
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { createWriteStream } from "fs";
+import { join } from "path";
+import { findStation } from "neaps";
+import { stations as db } from "@neaps/tide-database";
+import createFetch from "make-fetch-happen";
+
+const __dirname = new URL(".", import.meta.url).pathname;
+const fetch = createFetch.defaults({
+  cachePath: join(__dirname, ".cache"),
+  cache: "force-cache",
+  retry: 10,
+});
+
+const CHS_API = "https://api-sine.dfo-mpo.gc.ca/api/v1";
+
+// TICON ids for Canadian MEDS stations embed the CHS station code:
+// "sidney_bc-7260-can-meds" -> CHS code "07260".
+const stations = db
+  .filter((station) => station.source.id.endsWith("-can-meds"))
+  .map((station) => station.source.id);
+
+// Create a directory for test cache
+await mkdir(".test-cache", { recursive: true });
+
+interface Stat {
+  station: string;
+  scheme: string;
+  type: string;
+  start_utc: string;
+  end_utc: string;
+  events_chs: number;
+  events_model: number;
+  matched: number;
+  missed: number;
+  extra: number;
+  med_abs_dt_min: number;
+  p95_abs_dt_min: number;
+  mean_dt_min: number;
+  mae_dh_m: number;
+  mean_dh_m: number;
+  rmse_dh_m: number;
+  bias_dh_m: number;
+  p95_abs_dh_m: number;
+}
+
+const stats: Stat[] = [];
+const MATCH_WINDOW = 3 * 60 * 60 * 1000; // 3 hours
+const scheme = (process.env.SCHEME ?? "iho") as "iho" | "schureman";
+const FAST = !!process.env.FAST;
+const RANGE_DAYS = FAST ? 3 : 365;
+
+// Anchor the comparison window to the start of the current UTC month so
+// cached CHS responses stay valid within a month and roll over naturally.
+const now = new Date();
+const rangeStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+const rangeEnd = new Date(rangeStart.getTime() + RANGE_DAYS * 24 * 60 * 60 * 1000);
+const stamp = rangeStart.toISOString().slice(0, 10);
+
+console.log(
+  `Testing tide predictions against ${stations.length} CHS stations (scheme=${scheme}, days=${RANGE_DAYS})`,
+);
+
+type Extreme = {
+  time: number;
+  level: number;
+  type: "H" | "L";
+};
+
+// CHS hi/lo predictions ("wlp-hilo") are referenced to chart datum, which at
+// Canadian stations is neither LAT nor MLLW (e.g. Sidney BC: 0.43 m above
+// LAT). Each station's metadata carries the chart-datum -> LAT offset, so we
+// shift CHS levels onto LAT and ask the model for LAT, giving both sides the
+// same zero. Comparing without this mostly measures datum offsets (#223).
+const heightTypes: { id: string; code: string }[] = await fetchCHS("height-types", "height-types");
+const LAT_TYPE_ID = heightTypes.find((h) => h.code === "LAT")?.id;
+if (!LAT_TYPE_ID) throw new Error("CHS height-types has no LAT entry");
+
+const skipped = { noChsStation: 0, noLatDatum: 0, noPredictions: 0 };
+
+for (const id of stations) {
+  const code = id.match(/-(\d+)-can-meds$/)?.[1].padStart(5, "0");
+  if (!code) continue;
+
+  const found = await fetchCHS(`stations?code=${code}`, `station-${code}`);
+  const chsStation = found?.[0];
+  if (!chsStation) {
+    skipped.noChsStation += 1;
+    continue;
+  }
+
+  const metadata = await fetchCHS(`stations/${chsStation.id}/metadata`, `metadata-${code}`);
+  const latOffset = metadata?.heights?.find(
+    (h: { heightTypeId: string }) => h.heightTypeId === LAT_TYPE_ID,
+  )?.value;
+  if (latOffset === undefined) {
+    skipped.noLatDatum += 1;
+    continue;
+  }
+  // The metadata offset is LAT relative to chart datum (negative when LAT is
+  // below it); adding the negation shifts chart-datum levels onto LAT.
+  const chartDatumToLat = -latOffset;
+
+  const query = new URLSearchParams({
+    "time-series-code": "wlp-hilo",
+    from: rangeStart.toISOString().replace(/\.\d{3}Z$/, "Z"),
+    to: rangeEnd.toISOString().replace(/\.\d{3}Z$/, "Z"),
+  });
+  const rows = await fetchCHS(
+    `stations/${chsStation.id}/data?${query}`,
+    `hilo-${code}-${stamp}-${RANGE_DAYS}d`,
+  );
+  if (!Array.isArray(rows) || rows.length < 2) {
+    skipped.noPredictions += 1;
+    continue;
+  }
+
+  // CHS rows carry no H/L type; label by comparing neighbors. Pairwise
+  // comparison keeps any mislabel local if an event is ever missing, instead
+  // of cascading down the rest of the sequence.
+  const levels: number[] = rows.map((r: { value: string }) => parseFloat(r.value));
+  const chsEvents: Extreme[] = rows.map((r: { eventDate: string }, i: number) => ({
+    time: new Date(r.eventDate).getTime(),
+    level: levels[i] + chartDatumToLat,
+    type:
+      i < levels.length - 1
+        ? levels[i] > levels[i + 1]
+          ? ("H" as const)
+          : ("L" as const)
+        : levels[i] > levels[i - 1]
+          ? ("H" as const)
+          : ("L" as const),
+  }));
+
+  const station = findStation(["ticon", id].join("/"));
+
+  // Get start/end dates to match CHS data
+  const start = new Date(chsEvents[0].time - MATCH_WINDOW);
+  const end = new Date(chsEvents[chsEvents.length - 1].time + MATCH_WINDOW);
+
+  const neapsEvents: Extreme[] = station
+    .getExtremesPrediction({
+      start,
+      end,
+      datum: "LAT",
+      nodeCorrections: scheme,
+    })
+    .extremes.map((e) => ({
+      time: e.time.getTime(),
+      level: e.level,
+      type: e.high ? "H" : "L",
+    }));
+
+  let matched = 0;
+  let missed = 0;
+  let extra = 0;
+
+  const dtMinutes: number[] = [];
+  const dhMeters: number[] = [];
+
+  const chs = Object.groupBy(chsEvents, (e) => e.type) as Record<"H" | "L", Extreme[] | undefined>;
+  const neaps = Object.groupBy(neapsEvents, (e) => e.type) as Record<
+    "H" | "L",
+    Extreme[] | undefined
+  >;
+
+  const matchAndCollect = (chsList: Extreme[], neapsList: Extreme[]) => {
+    let j = 0;
+
+    for (let i = 0; i < chsList.length; i++) {
+      const chs = chsList[i];
+
+      // Count model events that are too early to ever match this CHS event as "extra"
+      while (j < neapsList.length && neapsList[j].time < chs.time - MATCH_WINDOW) {
+        extra += 1;
+        j += 1;
+      }
+
+      if (j >= neapsList.length) {
+        missed += 1;
+        continue;
+      }
+
+      // Consider the closest of current or next model event
+      let bestIndex = j;
+      let bestAbsDt = Math.abs(neapsList[j].time - chs.time);
+
+      if (j + 1 < neapsList.length) {
+        const nextAbsDt = Math.abs(neapsList[j + 1].time - chs.time);
+        if (nextAbsDt < bestAbsDt) {
+          bestIndex = j + 1;
+          bestAbsDt = nextAbsDt;
+        }
+      }
+
+      // If closest is outside the matching window, treat CHS event as missed
+      if (bestAbsDt > MATCH_WINDOW) {
+        missed += 1;
+        continue;
+      }
+
+      const match = neapsList[bestIndex];
+
+      // Advance pointer past the matched event (one-to-one matching)
+      j = bestIndex + 1;
+
+      matched += 1;
+
+      const dtMin = (match.time - chs.time) / 60000;
+      const dh = match.level - chs.level;
+
+      dtMinutes.push(dtMin);
+      dhMeters.push(dh);
+    }
+
+    // Any remaining model events are "extra"
+    extra += Math.max(0, neapsList.length - j);
+  };
+
+  matchAndCollect(chs.H ?? [], neaps.H ?? []);
+  matchAndCollect(chs.L ?? [], neaps.L ?? []);
+
+  const events_chs = (chs.H?.length ?? 0) + (chs.L?.length ?? 0);
+  const events_model = (neaps.H?.length ?? 0) + (neaps.L?.length ?? 0);
+
+  // Timing metrics (minutes)
+  const absDt = sort(dtMinutes.map((v) => Math.abs(v)));
+  const med_abs_dt_min = ntile(absDt, 0.5);
+  const p95_abs_dt_min = ntile(absDt, 0.95);
+  const mean_dt_min = mean(dtMinutes);
+
+  // Height metrics (meters) at matched events
+  const absDh = dhMeters.map((v) => Math.abs(v));
+  const mae_dh_m = mean(absDh);
+  const mean_dh_m = mean(dhMeters);
+  const rmse_dh_m = Math.sqrt(dhMeters.reduce((a, b) => a + b * b, 0) / dhMeters.length);
+  const bias_dh_m = mean(dhMeters);
+  const p95_abs_dh_m = ntile(sort(absDh), 0.95);
+
+  stats.push({
+    station: station.source.id,
+    scheme,
+    type: station.type,
+    start_utc: start.toISOString(),
+    end_utc: end.toISOString(),
+    events_chs,
+    events_model,
+    matched,
+    missed,
+    extra,
+    med_abs_dt_min,
+    p95_abs_dt_min,
+    mean_dt_min,
+    mae_dh_m,
+    mean_dh_m,
+    rmse_dh_m,
+    bias_dh_m,
+    p95_abs_dh_m,
+  });
+  process.stdout.write(".");
+}
+
+console.log(
+  `\nSkipped: ${skipped.noChsStation} without a CHS station, ` +
+    `${skipped.noLatDatum} without a LAT datum, ${skipped.noPredictions} without predictions`,
+);
+
+// Write stats to file for later analysis
+const summary = createWriteStream(join(__dirname, "chs.csv"));
+summary.write(
+  "station,scheme,type,start_utc,end_utc,events_chs,events_model,matched,missed,extra,med_abs_dt_min,p95_abs_dt_min,mean_dt_min,mae_dh_m,mean_dh_m,rmse_dh_m,bias_dh_m,p95_abs_dh_m\n",
+);
+
+stats.forEach((s) => {
+  summary.write(
+    [
+      s.station,
+      s.scheme,
+      s.type,
+      s.start_utc,
+      s.end_utc,
+      s.events_chs,
+      s.events_model,
+      s.matched,
+      s.missed,
+      s.extra,
+      s.med_abs_dt_min.toFixed(2),
+      s.p95_abs_dt_min.toFixed(2),
+      s.mean_dt_min.toFixed(2),
+      s.mae_dh_m.toFixed(4),
+      s.mean_dh_m.toFixed(4),
+      s.rmse_dh_m.toFixed(4),
+      s.bias_dh_m.toFixed(4),
+      s.p95_abs_dh_m.toFixed(4),
+    ].join(",") + "\n",
+  );
+});
+summary.end();
+
+// Baseline expectations based on current performance. The goal should be to
+// move these toward zero over time. TICON constituents are independently
+// derived, so residuals run higher than the NOAA benchmark (where the model
+// ingests NOAA's own constituents).
+const maeValues = sort(stats.map((s) => s.mae_dh_m));
+const p50MAE = ntile(maeValues, 0.5);
+const p90MAE = ntile(maeValues, 0.9);
+const p95MAE = ntile(maeValues, 0.95);
+
+const medAbsDtValues = sort(stats.map((s) => s.med_abs_dt_min));
+const p95MedAbsDt = ntile(medAbsDtValues, 0.95);
+
+console.log(`\n${scheme}:`, { count: stats.length, p50MAE, p90MAE, p95MAE, p95MedAbsDt });
+
+// Baseline expectations
+expect(p50MAE, "MAE p50").toBeLessThan(0.1); // 10 cm
+expect(p90MAE, "MAE p90").toBeLessThan(0.2); // 20 cm
+expect(p95MAE, "MAE p95").toBeLessThan(0.35); // 35 cm
+expect(p95MedAbsDt, "Median |dt| p95 across stations").toBeLessThanOrEqual(40);
+
+async function fetchCHS(path: string, cacheKey: string) {
+  const filePath = `./.test-cache/chs-${cacheKey}.json`;
+
+  try {
+    return await readFile(filePath, "utf-8").then((data) => JSON.parse(data));
+  } catch {
+    const res = await fetch(`${CHS_API}/${path}`);
+    const data = await res.json();
+    await writeFile(filePath, JSON.stringify(data));
+    return data;
+  }
+}
+
+function sort(data: number[]) {
+  return data.sort((a, b) => a - b);
+}
+
+function ntile(data: number[], percent: number) {
+  return data[Math.floor(data.length * percent)] ?? NaN;
+}
+
+function mean(data: number[]) {
+  return data.reduce((a, b) => a + b, 0) / data.length;
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "npm run build --workspaces --if-present && tsc",
     "lint": "eslint && prettier --check .",
     "format": "prettier --write .",
-    "benchmarks": "node benchmarks/noaa.ts",
+    "benchmarks": "run-s --continue-on-error \"benchmarks:*\"",
+    "benchmarks:noaa": "node benchmarks/noaa.ts",
+    "benchmarks:chs": "node benchmarks/chs.ts",
     "changeset": "changeset",
     "version": "changeset version",
     "release": "bash scripts/release.sh"


### PR DESCRIPTION
Closes #223.

Adds `benchmarks/chs.ts`, a sibling of the NOAA benchmark for the 226 Canadian MEDS-sourced TICON stations.

**How it works**
- TICON ids embed the CHS station code (`sidney_bc-7260-can-meds` → `07260`), so the join to the CHS API needs no lookup table.
- CHS `wlp-hilo` predictions are referenced to **chart datum**, which is neither LAT nor MLLW at Canadian stations (Sidney: 0.43 m above LAT). Each station's `/metadata` carries the offset, so CHS levels get shifted onto LAT and the model is asked for `datum: "LAT"` — without this the benchmark mostly measures datum offsets (see the analysis in #223).
- CHS rows carry no H/L type; events are labeled by neighbor comparison.
- Matching/stats/CSV mirror `noaa.ts`. Kept self-contained rather than extracting shared helpers, since `allowImportingTsExtensions: false` plus node type-stripping makes a shared `.ts` import awkward — happy to consolidate if you'd rather flip that flag.

**CI**
- The benchmarks job moves to a reusable `benchmarks.yml`, called from `ci.yml` as before, plus `workflow_dispatch` and a monthly `schedule` so both benchmarks re-run against fresh reference predictions even without pushes.
- The cache key is month-stamped, and `chs.ts` anchors its comparison window to the current UTC month, so cached CHS responses stay coherent within a month and roll over naturally.

**Baselines** (current performance, same philosophy as noaa.ts): MAE p50 < 10 cm, p90 < 20 cm, p95 < 35 cm, p95-of-median-|Δt| ≤ 40 min. Measured: full-year 7.3/16.4/25.7 cm + 23.5 min; FAST (3-day) 6.5/17.0/29.6 cm + 33.2 min. Looser than NOAA's 2–3 cm because TICON constituents are independently derived rather than ingested from the reference source.

**Skips:** 13 codes with no current CHS station, 30 stations whose CHS metadata has no LAT entry, 3 without predictions → 180 benchmarked.

**Things the CSV already surfaces** (left for follow-up, not addressed here): the `cape_dor-240` outlier (+3.5 m constant bias, implausible 18.6 m HAT−LAT span), several 0.3–0.5 m constant-bias stations, and shallow-water/river timing tails.

Tested: `tsc`, `eslint`, `prettier` clean; FAST and full-year runs locally; `npm run benchmarks` runs both suites.
