### PR TITLE
Add changeset for Express 5 in @neaps/api

### DIFF
--- a/.changeset/express-5.md
+++ b/.changeset/express-5.md
@@ -1,5 +1,5 @@
 ---
-"@neaps/api": patch
+"@neaps/api": minor
 ---
 
 Update `express` to v5.

--- a/.changeset/express-5.md
+++ b/.changeset/express-5.md
@@ -1,0 +1,5 @@
+---
+"@neaps/api": patch
+---
+
+Update `express` to v5.


### PR DESCRIPTION
Adds a changeset for the Express 5 bump in `@neaps/api` (#203, #204) so it shows up in the next release notes.

`@neaps/api` only exposes a Router and reads `req.query`, so Express 5 needs no code changes here. Verified against the neaps test suite.
