### PR TITLE
Only collapse TideStation to tabs when height-constrained

### DIFF
--- a/.changeset/tide-station-responsive-height.md
+++ b/.changeset/tide-station-responsive-height.md
@@ -1,0 +1,5 @@
+---
+"@neaps/react": patch
+---
+
+`<TideStation>` no longer collapses into the tabbed layout based on width alone. Narrow content-sized containers (like phones in portrait) now keep the stacked continuous-scroll view; tabs only appear when an ancestor constrains the height below 500px and the stacked content overflows (e.g. a fixed-size dashboard widget). The tab bar collapses into a dropdown based on height (below 260px) instead of width.

--- a/packages/react/src/components/TideStation.stories.tsx
+++ b/packages/react/src/components/TideStation.stories.tsx
@@ -23,13 +23,14 @@ export const Default: Story = {
   },
 };
 
+/** Narrow dashboard widget: fixed height forces the tabbed layout */
 export const WidgetSize: Story = {
   args: {
     id: "noaa/8443970",
   },
   decorators: [
     (Story) => (
-      <div style={{ maxWidth: 250 }}>
+      <div style={{ width: 250, height: 400 }}>
         <Story />
       </div>
     ),

--- a/packages/react/src/components/TideStation.tsx
+++ b/packages/react/src/components/TideStation.tsx
@@ -15,38 +15,42 @@ import { StationDisclaimers } from "./StationDisclaimers.js";
 import { TideSettings } from "./TideSettings.js";
 import { getDefaultRange } from "../utils/defaults.js";
 
-// Below either of these container dimensions the stacked layout can't fit,
-// so the sections collapse into tabs (e.g. embedded as a dashboard widget).
-const COMPACT_MAX_WIDTH = 500;
+// A height-constrained container shorter than this can't fit the stacked
+// layout, so the sections collapse into tabs (e.g. embedded as a dashboard
+// widget). Width alone never collapses: a narrow content-sized container
+// (a phone in portrait) grows to fit its content and the page scrolls.
 const COMPACT_MAX_HEIGHT = 500;
+// Below this height the tab bar itself crowds out the panel, so it collapses
+// further into a dropdown beside the station name.
+const DROPDOWN_MAX_HEIGHT = 260;
 
 const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
-type CompactReason = "width" | "height";
-
-function evaluateCompact(el: HTMLElement, prev: CompactReason | null): CompactReason | null {
-  const { clientWidth, clientHeight, scrollHeight } = el;
-  if (clientWidth === 0) return prev;
-  if (clientWidth < COMPACT_MAX_WIDTH) return "width";
-  if (clientHeight >= COMPACT_MAX_HEIGHT) return null;
+function evaluateCompact(el: HTMLElement, prev: boolean): boolean {
+  const { clientHeight, scrollHeight } = el;
+  if (clientHeight >= COMPACT_MAX_HEIGHT) return false;
   // Below the height threshold. A content-sized container is always at least
   // as tall as its content, so a height this small with overflowing content
   // means an ancestor is constraining us (e.g. a fixed-size dashboard panel).
   // Stay collapsed once collapsed: the tabbed layout fits by design, so
   // overflow would never re-trigger.
-  if (prev === "height") return "height";
-  return scrollHeight > clientHeight + 1 ? "height" : null;
+  return prev || scrollHeight > clientHeight + 1;
 }
 
 function useCompactLayout() {
   const [element, setElement] = useState<HTMLDivElement | null>(null);
-  const [reason, setReason] = useState<CompactReason | null>(null);
+  const [compact, setCompact] = useState(false);
+  const [short, setShort] = useState(false);
+
+  const measure = (el: HTMLElement) => {
+    if (el.clientWidth === 0) return; // not laid out (e.g. display: none)
+    setCompact((prev) => evaluateCompact(el, prev));
+    setShort(el.clientHeight < DROPDOWN_MAX_HEIGHT);
+  };
 
   useEffect(() => {
     if (!element) return;
-    const observer = new ResizeObserver(() => {
-      setReason((prev) => evaluateCompact(element, prev));
-    });
+    const observer = new ResizeObserver(() => measure(element));
     observer.observe(element);
     return () => observer.disconnect();
   }, [element]);
@@ -54,10 +58,10 @@ function useCompactLayout() {
   // Re-evaluate after every render: swapping layouts changes the content size
   // without resizing the container, which ResizeObserver doesn't report.
   useIsomorphicLayoutEffect(() => {
-    if (element) setReason((prev) => evaluateCompact(element, prev));
+    if (element) measure(element);
   });
 
-  return { ref: setElement, compact: reason !== null };
+  return { ref: setElement, compact, dropdown: compact && short };
 }
 
 type TabId = "conditions" | "graph" | "table" | "settings";
@@ -84,7 +88,7 @@ export function TideStation({
 }: TideStationProps) {
   const config = useNeapsConfig();
   const range = useMemo(getDefaultRange, []);
-  const { ref, compact } = useCompactLayout();
+  const { ref, compact, dropdown } = useCompactLayout();
 
   const tabs = useMemo<TabId[]>(() => {
     const ids: TabId[] = ["conditions"];
@@ -139,13 +143,9 @@ export function TideStation({
       >
         <div className="flex items-start justify-between gap-2">
           <TideStationHeader station={s} className="min-w-0 flex-1" />
-          {/* At very narrow widths the tab bar collapses into this dropdown */}
-          <TabsDropdown
-            tabs={tabs}
-            active={activeTab}
-            onSelect={setActiveTab}
-            className="@sm/station:hidden"
-          />
+          {/* When the container is too short for the tab bar, it collapses
+              into this dropdown */}
+          {dropdown && <TabsDropdown tabs={tabs} active={activeTab} onSelect={setActiveTab} />}
         </div>
         <TideStationTabs
           id={id}
@@ -157,6 +157,7 @@ export function TideStation({
           tabs={tabs}
           active={activeTab}
           onSelect={setActiveTab}
+          tabBar={!dropdown}
         />
       </div>
     );
@@ -197,6 +198,7 @@ function TideStationTabs({
   tabs,
   active,
   onSelect,
+  tabBar,
 }: {
   id: string;
   station: Station;
@@ -207,6 +209,7 @@ function TideStationTabs({
   tabs: TabId[];
   active: TabId;
   onSelect: (tab: TabId) => void;
+  tabBar: boolean;
 }) {
   const uid = useId();
   const tabRefs = useRef<Partial<Record<TabId, HTMLButtonElement | null>>>({});
@@ -257,16 +260,18 @@ function TideStationTabs({
 
   return (
     <>
-      <div
-        role="tablist"
-        aria-label="Tide station sections"
-        onKeyDown={onKeyDown}
-        className="hidden @sm/station:flex items-center border-b border-(--neaps-border)"
-      >
-        {tabs.filter((tab) => tab !== "settings").map(tabButton)}
-        <span className="flex-1" />
-        {tabButton("settings")}
-      </div>
+      {tabBar && (
+        <div
+          role="tablist"
+          aria-label="Tide station sections"
+          onKeyDown={onKeyDown}
+          className="flex items-center border-b border-(--neaps-border)"
+        >
+          {tabs.filter((tab) => tab !== "settings").map(tabButton)}
+          <span className="flex-1" />
+          {tabButton("settings")}
+        </div>
+      )}
 
       <div
         role="tabpanel"
@@ -299,22 +304,20 @@ function TideStationTabs({
   );
 }
 
-// Replaces the tab bar when the container is too narrow for it: a visually
+// Replaces the tab bar when the container is too short for it: a visually
 // combined icon + chevron with an invisible native select on top, so picking
 // a section keeps native dropdown behavior and accessibility.
 function TabsDropdown({
   tabs,
   active,
   onSelect,
-  className,
 }: {
   tabs: TabId[];
   active: TabId;
   onSelect: (tab: TabId) => void;
-  className?: string;
 }) {
   return (
-    <div className={`relative shrink-0 ${className ?? ""}`}>
+    <div className="relative shrink-0">
       <span
         aria-hidden="true"
         className="flex items-center gap-1 px-2 py-1.5 rounded-md border border-(--neaps-border) text-(--neaps-text-muted)"

--- a/packages/react/src/components/TideStation.tsx
+++ b/packages/react/src/components/TideStation.tsx
@@ -273,10 +273,13 @@ function TideStationTabs({
         </div>
       )}
 
+      {/* Without the tab bar there are no tab elements to label the panel,
+          so it becomes a plain named region */}
       <div
-        role="tabpanel"
+        role={tabBar ? "tabpanel" : "region"}
         id={panelId(active)}
-        aria-labelledby={tabId(active)}
+        aria-labelledby={tabBar ? tabId(active) : undefined}
+        aria-label={tabBar ? undefined : TAB_LABELS[active]}
         tabIndex={0}
         className={`flex-1 min-h-0 ${active === "settings" ? "overflow-y-auto" : "overflow-hidden"}`}
       >

--- a/packages/react/test/a11y.test.tsx
+++ b/packages/react/test/a11y.test.tsx
@@ -95,6 +95,26 @@ describe("accessibility", () => {
     await checkA11y(container);
   });
 
+  test("TideStation dropdown (short container) layout has no violations", { timeout: 15000 }, async () => {
+    const { container } = render(
+      <div style={{ width: 400, height: 220 }}>
+        <TideStation id={STATION_ID} />
+      </div>,
+      { wrapper: createTestWrapper() },
+    );
+    const view = within(container);
+
+    await waitFor(
+      () => {
+        expect(view.queryByText("Loading...")).toBeNull();
+        expect(view.getByRole("combobox", { name: "Section" })).toBeDefined();
+      },
+      { timeout: 10000 },
+    );
+
+    await checkA11y(container);
+  });
+
   test("TideGraphChart with data has no violations", async () => {
     const timeline = [
       { time: new Date("2025-12-17T00:00:00Z"), level: 0.5 },

--- a/packages/react/test/a11y.test.tsx
+++ b/packages/react/test/a11y.test.tsx
@@ -95,25 +95,29 @@ describe("accessibility", () => {
     await checkA11y(container);
   });
 
-  test("TideStation dropdown (short container) layout has no violations", { timeout: 15000 }, async () => {
-    const { container } = render(
-      <div style={{ width: 400, height: 220 }}>
-        <TideStation id={STATION_ID} />
-      </div>,
-      { wrapper: createTestWrapper() },
-    );
-    const view = within(container);
+  test(
+    "TideStation dropdown (short container) layout has no violations",
+    { timeout: 15000 },
+    async () => {
+      const { container } = render(
+        <div style={{ width: 400, height: 220 }}>
+          <TideStation id={STATION_ID} />
+        </div>,
+        { wrapper: createTestWrapper() },
+      );
+      const view = within(container);
 
-    await waitFor(
-      () => {
-        expect(view.queryByText("Loading...")).toBeNull();
-        expect(view.getByRole("combobox", { name: "Section" })).toBeDefined();
-      },
-      { timeout: 10000 },
-    );
+      await waitFor(
+        () => {
+          expect(view.queryByText("Loading...")).toBeNull();
+          expect(view.getByRole("combobox", { name: "Section" })).toBeDefined();
+        },
+        { timeout: 10000 },
+      );
 
-    await checkA11y(container);
-  });
+      await checkA11y(container);
+    },
+  );
 
   test("TideGraphChart with data has no violations", async () => {
     const timeline = [

--- a/packages/react/test/components/TideStation.test.tsx
+++ b/packages/react/test/components/TideStation.test.tsx
@@ -147,6 +147,14 @@ describe("TideStation", () => {
       expect(view.getByRole("tablist")).toBeDefined();
     });
 
+    test("stays stacked when narrow but not height-constrained (phone portrait)", async () => {
+      const { view } = await renderCompact({ width: 375 });
+
+      expect(view.queryByRole("tablist")).toBeNull();
+      expect(view.queryByRole("combobox", { name: "Section" })).toBeNull();
+      expect(view.getByRole("table")).toBeDefined();
+    });
+
     test("switches tabs on click and updates the URL hash", async () => {
       const user = userEvent.setup();
       const { view } = await renderCompact();
@@ -175,9 +183,9 @@ describe("TideStation", () => {
       expect(view.getByRole("table")).toBeDefined();
     });
 
-    test("collapses the tab bar into a dropdown at very narrow widths", async () => {
+    test("collapses the tab bar into a dropdown when the container is too short", async () => {
       const user = userEvent.setup();
-      const { view } = await renderCompact({ width: 250, height: 220 });
+      const { view } = await renderCompact({ width: 400, height: 220 });
 
       expect(view.queryByRole("tablist")).toBeNull();
       const dropdown = view.getByRole("combobox", { name: "Section" });
@@ -188,7 +196,7 @@ describe("TideStation", () => {
       expect(window.location.hash).toBe("#table");
     });
 
-    test("shows the tab bar instead of the dropdown when wide enough", async () => {
+    test("shows the tab bar instead of the dropdown when tall enough", async () => {
       const { view } = await renderCompact({ width: 400, height: 320 });
 
       expect(view.getByRole("tablist")).toBeDefined();


### PR DESCRIPTION
Fixes #284

## Problem

`<TideStation>` collapsed into the compact tabbed layout whenever its container was narrower than 500px. Phones in portrait (~375–430 CSS px) are always below that threshold, so mobile users could never get the stacked continuous-scroll layout — even with unlimited vertical space.

## Change

- **Tabs trigger:** width is no longer considered. The component collapses to tabs only when the container is *height-constrained*: `clientHeight < 500` **and** the stacked content overflows (`scrollHeight > clientHeight`). A content-sized container (phone, narrow desktop window) grows with its content and never overflows, so it stays stacked. A fixed-size dashboard widget overflows and gets tabs.
- **Dropdown trigger:** the tab bar now collapses into the dropdown based on height (`clientHeight < 260`, where the tab bar starts crowding out the panel) instead of a width container query. Measured in `useCompactLayout` via the existing `ResizeObserver` — CSS height container queries would require `container-type: size`, which breaks auto-height containers. The icon tab bar fits down to ~160px wide, so no width fallback is needed.
- `WidgetSize` story constrained only width, which is now a phone-shaped container — it gets a fixed height to actually model a dashboard widget.

The `layout` override prop proposed in the issue is intentionally omitted: auto-detection now covers the reported case. It can be added later if someone hits a case the heuristic misses. The iOS Chrome graph-not-loading screenshot in the issue is a separate bug.

## Behavior matrix

| Container | Before | After |
|---|---|---|
| Phone portrait (375px, page scrolls) | tabs | **stacked** |
| Narrow desktop window | stacked | stacked |
| Fixed widget 250×400 | tabs (dropdown) | tabs |
| Fixed widget 250×200 | tabs (dropdown) | tabs → dropdown |
| Fixed panel 400×320 | tabs | tabs |
| Fixed panel ≥ 500px tall | stacked | stacked |

## Testing

- New regression test: 375px-wide unconstrained container stays stacked
- Dropdown tests now exercise height (400×220 → dropdown, 400×320 → tab bar)
- Full `@neaps/react` suite passes (222 tests, real Chromium browser mode)
- Verified visually in Storybook at phone/widget/thumbnail/panel sizes