### PR TITLE
Fix main build: import GeoJSON types explicitly in StationsMap

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -74,6 +74,7 @@
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/culori": "^4.0.1",
+    "@types/geojson": "^7946.0.16",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitest/browser-playwright": "^4.0.18",

--- a/packages/react/src/components/StationsMap.tsx
+++ b/packages/react/src/components/StationsMap.tsx
@@ -17,6 +17,7 @@ import {
   type MapEvent,
 } from "react-map-gl/maplibre";
 import "maplibre-gl/dist/maplibre-gl.css";
+import type { FeatureCollection, Point } from "geojson";
 import { keepPreviousData } from "@tanstack/react-query";
 
 import { useStation } from "../hooks/use-station.js";
@@ -54,7 +55,7 @@ export interface StationsMapProps extends Omit<ComponentProps<typeof Map>, Manag
   className?: string;
 }
 
-function stationsToGeoJSON(stations: StationSummary[]): GeoJSON.FeatureCollection {
+function stationsToGeoJSON(stations: StationSummary[]): FeatureCollection {
   return {
     type: "FeatureCollection",
     features: stations.map(({ longitude, latitude, ...properties }) => ({
@@ -118,7 +119,7 @@ export const StationsMap = forwardRef<MapRef, StationsMapProps>(function Station
     [stations, focusStation],
   );
 
-  const focusGeoJSON: GeoJSON.FeatureCollection | null = useMemo(() => {
+  const focusGeoJSON: FeatureCollection | null = useMemo(() => {
     if (!focusStationData) return null;
     return stationsToGeoJSON([focusStationData]);
   }, [focusStationData]);
@@ -159,8 +160,8 @@ export const StationsMap = forwardRef<MapRef, StationsMapProps>(function Station
       if (props?.cluster) {
         setViewState((prev) => ({
           ...prev,
-          longitude: (feature.geometry as GeoJSON.Point).coordinates[0],
-          latitude: (feature.geometry as GeoJSON.Point).coordinates[1],
+          longitude: (feature.geometry as Point).coordinates[0],
+          latitude: (feature.geometry as Point).coordinates[1],
           zoom: Math.min((prev.zoom ?? 3) + 2, 18),
         }));
         return;
@@ -168,7 +169,7 @@ export const StationsMap = forwardRef<MapRef, StationsMapProps>(function Station
 
       // Station point click
       if (props?.id) {
-        const coords = (feature.geometry as GeoJSON.Point).coordinates;
+        const coords = (feature.geometry as Point).coordinates;
         const station = {
           ...props,
           latitude: coords[1],


### PR DESCRIPTION
## Problem

`main` is red: `packages/react/src/components/StationsMap.tsx` fails to compile with `TS2503: Cannot find namespace 'GeoJSON'` (5 occurrences), which breaks every build job.

The component leaned on the ambient global `GeoJSON` namespace (`GeoJSON.FeatureCollection`, `GeoJSON.Point`). That global came in transitively through react-map-gl v7 / maplibre-gl v4's types. The bumps to react-map-gl v8 and maplibre-gl v5 (#277, #279) dropped it. The root tsconfig pins `types: ["vite/client"]`, which turns off automatic `@types` inclusion, so having `@types/geojson` transitively in the tree doesn't bring the global back.

## Fix

Import the types explicitly instead of relying on the leaked global:

- `import type { FeatureCollection, Point } from "geojson"` in `StationsMap.tsx`, and drop the `GeoJSON.` prefix on the 5 usages
- add `@types/geojson` as an explicit devDependency of `@neaps/react`, since it's now imported directly

## Testing

Clean install + `npm run build` passes. Before the fix it failed with the 5 `TS2503` errors.
