### PR TITLE
Add s-maxage to API Cache-Control header

### DIFF
--- a/.changeset/cache-control-s-maxage.md
+++ b/.changeset/cache-control-s-maxage.md
@@ -1,0 +1,5 @@
+---
+"@neaps/api": patch
+---
+
+Add `s-maxage` to the `Cache-Control` header so CDNs and edge caches (e.g. Vercel, Cloudflare) cache responses, not just browsers. Uses the same TTL as `max-age` (`NEAPS_API_MAX_AGE`, default 3600).

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -24,7 +24,8 @@ export function createApp({ prefix = "/tides" } = {}) {
 
   // Cache-Control middleware
   app.use((_req, res, next) => {
-    res.setHeader("Cache-Control", `public, max-age=${MAX_AGE}`);
+    // s-maxage lets CDNs (e.g. Vercel's edge) cache responses, not just browsers
+    res.setHeader("Cache-Control", `public, max-age=${MAX_AGE}, s-maxage=${MAX_AGE}`);
     next();
   });
 

--- a/packages/api/test/index.test.ts
+++ b/packages/api/test/index.test.ts
@@ -660,7 +660,9 @@ describe("HTTP Caching", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(response.headers["cache-control"]).toBe("public, max-age=3600");
+    expect(response.headers["cache-control"]).toBe(
+      "public, max-age=3600, s-maxage=3600",
+    );
   });
 
   test("returns 304 when ETag matches", async () => {

--- a/packages/api/test/index.test.ts
+++ b/packages/api/test/index.test.ts
@@ -660,9 +660,7 @@ describe("HTTP Caching", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(response.headers["cache-control"]).toBe(
-      "public, max-age=3600, s-maxage=3600",
-    );
+    expect(response.headers["cache-control"]).toBe("public, max-age=3600, s-maxage=3600");
   });
 
   test("returns 304 when ETag matches", async () => {


### PR DESCRIPTION
Responses currently only set `Cache-Control: public, max-age=...`, which is browser-only. CDNs and edge caches generally require `s-maxage` to cache shared responses, so every request was hitting the origin — a full tide-database module load plus harmonic prediction math each time.

## What

Append `s-maxage=${MAX_AGE}` to the existing `Cache-Control` middleware, using the same TTL as `max-age` (`NEAPS_API_MAX_AGE`, default 3600). Shared caches can now serve repeat requests without touching the origin.

Request keys are already cache-friendly: `@neaps/react`'s `use-tide-chunks` aligns `start`/`end` to local-midnight day boundaries, so timeline/extremes URLs bin to station × day × tz-offset × units.

## Testing

Updated the header assertion; full suite passes (64/64).