### PR TITLE
Update @neaps/tide-database to 0.9

### DIFF
--- a/.changeset/tide-database-0-9.md
+++ b/.changeset/tide-database-0-9.md
@@ -1,0 +1,8 @@
+---
+"neaps": minor
+"@neaps/cli": minor
+---
+
+Update @neaps/tide-database to 0.9. Station prediction data now lives in an
+off-heap pack file read per station instead of being parsed into the JS heap
+at import, dropping baseline heap usage from ~118 MB to ~36 MB.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@neaps/api": "^0.6.0",
-    "@neaps/tide-database": "0.8",
+    "@neaps/tide-database": "0.9",
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "commander": "^15.0.0",

--- a/packages/neaps/package.json
+++ b/packages/neaps/package.json
@@ -33,7 +33,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@neaps/tide-database": "0.8",
+    "@neaps/tide-database": "0.9",
     "@neaps/tide-predictor": "^0.10.0"
   }
 }


### PR DESCRIPTION
Bumps neaps and @neaps/cli to @neaps/tide-database 0.9, the release with the off-heap prediction-data pack (openwatersio/tide-database#103). Baseline heap drops from ~118 MB to ~36 MB since station data is read from the pack per station instead of being parsed into the heap at import. All 1,438 tests pass against 0.9.

## Merge order

This must land after #293. @neaps/api currently bundles tide-database into its dist, which breaks with 0.9: the node build reads `generated/stations.pack` relative to `import.meta.url`, and the bundle doesn't carry the asset (verified: the built dist throws ENOENT). #293 makes tide-database an external dependency of @neaps/api, which resolves that; the api-side 0.9 bump is included there.